### PR TITLE
Fix apiRequest usage and type auth hook

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+DentalAutomationHub-2/node_modules/

--- a/DentalAutomationHub-2/client/src/components/layout/footer.tsx
+++ b/DentalAutomationHub-2/client/src/components/layout/footer.tsx
@@ -14,11 +14,7 @@ export default function Footer() {
 
   const newsletterMutation = useMutation({
     mutationFn: async (data: InsertNewsletter) => {
-      return await apiRequest("/api/newsletter", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify(data)
-      });
+      return await apiRequest("POST", "/api/newsletter", data);
     },
     onSuccess: () => {
       toast({

--- a/DentalAutomationHub-2/client/src/components/sections/cta.tsx
+++ b/DentalAutomationHub-2/client/src/components/sections/cta.tsx
@@ -30,11 +30,7 @@ export default function CTA() {
 
   const demoMutation = useMutation({
     mutationFn: async (data: InsertDemoRequest) => {
-      return await apiRequest("/api/demo-request", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify(data)
-      });
+      return await apiRequest("POST", "/api/demo-request", data);
     },
     onSuccess: () => {
       toast({

--- a/DentalAutomationHub-2/client/src/components/sections/newsletter.tsx
+++ b/DentalAutomationHub-2/client/src/components/sections/newsletter.tsx
@@ -16,11 +16,7 @@ export default function Newsletter() {
 
   const newsletterMutation = useMutation({
     mutationFn: async (data: InsertNewsletter) => {
-      return await apiRequest("/api/newsletter", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify(data)
-      });
+      return await apiRequest("POST", "/api/newsletter", data);
     },
     onSuccess: () => {
       toast({

--- a/DentalAutomationHub-2/client/src/hooks/useAuth.ts
+++ b/DentalAutomationHub-2/client/src/hooks/useAuth.ts
@@ -1,7 +1,8 @@
 import { useQuery } from "@tanstack/react-query";
+import type { User } from "@shared/schema";
 
 export function useAuth() {
-  const { data: user, isLoading, error } = useQuery({
+  const { data: user, isLoading, error } = useQuery<User | null>({
     queryKey: ["/api/auth/user"],
     retry: false,
   });


### PR DESCRIPTION
## Summary
- call `apiRequest` with method, url, and data in newsletter, CTA, and footer components
- type `useAuth` hook to return `User | null`
- add gitignore for node modules

## Testing
- `npm run check`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689d57951a24832ea64a1334d2583691